### PR TITLE
Add python requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4
+feedparser
+records


### PR DESCRIPTION
Using a requirements.txt file, you are able to run `pip install -r requirements.txt` to install all the necessary dependencies automatically. (see https://pip.pypa.io/en/stable/user_guide/#requirements-files for more information)